### PR TITLE
new warning messages

### DIFF
--- a/spark_matcher/matching_base/matching_base.py
+++ b/spark_matcher/matching_base/matching_base.py
@@ -28,15 +28,18 @@ class MatchingBase:
                  blocking_recall: float = 1.0, n_perfect_train_matches=1, n_train_samples: int = 100_000,
                  ratio_hashed_samples: float = 0.5, scorer: Optional[Scorer] = None, verbose: int = 0):
         self.spark_session = spark_session
-        self.table_checkpointer = table_checkpointer
         if not self.table_checkpointer and checkpoint_dir:
             self.table_checkpointer = ParquetCheckPointer(self.spark_session, checkpoint_dir, "checkpoint_deduplicator")
+        elif table_checkpointer and not checkpoint_dir:
+            self.table_checkpointer = table_checkpointer
         else:
             warnings.warn(
                 'Either `table_checkpointer` or `checkpoint_dir` should be provided. This instance can only be used '
                 'when loading a previously saved instance.')
 
-        if col_names:
+        if col_names and field_info:
+            raise ValueError("Either `col_names` or `field_info` should be provided.")
+        elif col_names:
             self.col_names = col_names
             self.field_info = {col_name: [token_set_ratio, token_sort_ratio] for col_name in
                                self.col_names}


### PR DESCRIPTION
Fixes ambiguous warning messages for `table_checkpoint` and `checkpoint_dir`
Adds ValueError when both `col_names` and `field_info` are given

```
def if_else(a, b):
	""""""
	if not a and b:
		pass
	else:
		print(f"warning. a: {a}, b: {b}.")

a, b = True, True
if_else(a, b)
a, b = False, True
if_else(a, b)
a, b = True, False
if_else(a, b)
a, b = False, False
if_else(a, b)

$ warning. a: True, b: True.
$ warning. a: True, b: False.
$ warning. a: False, b: False.
```
