### PR TITLE
Fix deduplicator checkpoint directory and set default value

### DIFF
--- a/spark_matcher/deduplicator/deduplicator.py
+++ b/spark_matcher/deduplicator/deduplicator.py
@@ -54,7 +54,7 @@ class Deduplicator(MatchingBase):
     def __init__(self, spark_session: SparkSession, col_names: Optional[List[str]] = None,
                  field_info: Optional[Dict] = None, blocking_rules: Optional[List[BlockingRule]] = None,
                  blocking_recall: float = 1.0, table_checkpointer: Optional[TableCheckpointer] = None,
-                 checkpoint_dir: Optional[str] = None, n_perfect_train_matches=1, n_train_samples: int = 100_000,
+                 checkpoint_dir: str = '/checkpoints/', n_perfect_train_matches=1, n_train_samples: int = 100_000,
                  ratio_hashed_samples: float = 0.5, scorer: Optional[Scorer] = None, verbose: int = 0,
                  max_edges_clustering: int = 500_000,
                  edge_filter_thresholds: List[float] = [0.45, 0.55, 0.65, 0.75, 0.85, 0.95],
@@ -72,7 +72,7 @@ class Deduplicator(MatchingBase):
             raise ValueError(f"Invalid cluster_linkage_method: {cluster_linkage_method}")
         self.cluster_linkage_method = cluster_linkage_method
         # set the checkpoints directory for graphframes
-        self.spark_session.sparkContext.setCheckpointDir('checkpoints/')
+        self.spark_session.sparkContext.setCheckpointDir(checkpoint_dir)
 
     def _create_predict_pairs_table(self, sdf_blocked: DataFrame) -> DataFrame:
         """

--- a/spark_matcher/matching_base/matching_base.py
+++ b/spark_matcher/matching_base/matching_base.py
@@ -205,7 +205,7 @@ class MatchingBase:
             sdf = sdf.withColumnRenamed(col, f"{col}_{suffix}")
         return sdf
 
-    def fit(self, sdf_1: DataFrame, sdf_2: Optional[DataFrame] = None) -> 'MatchingBase':
+    def fit(self, sdf_1: DataFrame, sdf_2: Optional[DataFrame] = None, ) -> 'MatchingBase':
         """
         Fit the MatchingBase instance on the two dataframes `sdf_1` and `sdf_2` using active learning. You will be
         prompted to enter whether the presented pairs are a match or not. Note that `sdf_2` is an optional argument.
@@ -220,14 +220,18 @@ class MatchingBase:
             Fitted MatchingBase instance
 
         """
+        # print("sdf_1", sdf_1)
         sdf_1 = self._simplify_dataframe_for_matching(sdf_1)
         if sdf_2:
             sdf_2 = self._simplify_dataframe_for_matching(sdf_2)
-
+        # print("sdf_1", sdf_1)
         pairs_table = self._create_train_pairs_table(sdf_1, sdf_2)
+        # print("pairs_table", pairs_table)
         metrics_table = self._calculate_metrics(pairs_table)
+        # print("metrics_table", metrics_table)
         metrics_table_pdf = metrics_table.toPandas()
-        self.scoring_learner.fit(metrics_table_pdf)
+        # print("metrics_table_pdf", metrics_table_pdf)
+        self.scoring_learner.fit(metrics_table_pdf, self.field_info)
         block_learning_input = self._create_blocklearning_input(metrics_table_pdf)
         self.blocker.fit(block_learning_input)
         self.fitted_ = True

--- a/spark_matcher/similarity_metrics/similarity_metrics.py
+++ b/spark_matcher/similarity_metrics/similarity_metrics.py
@@ -66,7 +66,7 @@ class SimilarityMetrics:
 
         return similarity_udf
 
-    def _apply_distance_metrics(self) -> Column:
+    def _apply_distance_metrics(self, return_iterable=False) -> Column:
         """
         Function to apply all distance metrics in the right order to string pairs and returns them in an array. This
         array is used as input to the (logistic regression) scoring function.
@@ -83,6 +83,9 @@ class SimilarityMetrics:
                     SimilarityMetrics._create_similarity_metric_udf(similarity_function)(F.col(field_name_1),
                                                                                          F.col(field_name_2)))
                 distance_metrics_list.append(similarity_metric)
+
+        if return_iterable:
+            return distance_metrics_list
 
         array = F.array(*distance_metrics_list)
 


### PR DESCRIPTION
The default `checkpoints/` directory for the deduplicator graphframes checkpoints was raising issues on Databricks saying that an absolute path must be specified. This change fixes this problem. It also specifies a default `/checkpoints/` value for the checkpoint parameter, as the checkpoint directory cannot be set to `None` anyway for prediction.

Closes #21.